### PR TITLE
Take into account shells not configured with an english locale which make it fail

### DIFF
--- a/bashtop
+++ b/bashtop
@@ -28,7 +28,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-declare -x LC_MESSAGES="C" LC_NUMERIC="C"
+declare -x LC_MESSAGES="C" LC_NUMERIC="C" LC_ALL="C.UTF8"
 shopt -qu failglob nullglob
 shopt -qs extglob globasciiranges globstar
 

--- a/bashtop
+++ b/bashtop
@@ -28,7 +28,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-declare -x LC_MESSAGES="C" LC_NUMERIC="C" LC_ALL="C.UTF8"
+declare -x LC_MESSAGES="C" LC_NUMERIC="C" LC_ALL=""
 shopt -qu failglob nullglob
 shopt -qs extglob globasciiranges globstar
 


### PR DESCRIPTION
If using an LC_ALL that is not in EN, then you get the following errors in ~/.config/bashtop/error.log:

```
14:28:27 ERROR: On line 645 
14:28:27 ERROR: On line 649 
14:28:27 ERROR: On line 191 
./bashtop: ligne 1565: ( ( 1110478-1110478 ) * 1000 * 1000 ) / ( cpu[hz]*time_elapsed*cpu[threads] )  : division par 0 (le symbole erroné est « ( cpu[hz]*time_elapsed*cpu[threads] )  »)
```

This is because lscpu returns text that cannot be interpreted by the script since it looks for English strings...

This pull request unsets LC_ALL as discussed with @aristocratos in pull request #23 