### PR TITLE
Fix color theme numbering

### DIFF
--- a/bashtop
+++ b/bashtop
@@ -757,8 +757,7 @@ get_themes() {
 	for file in "${theme_dir}"/*.theme; do
 		file="${file##*/}"
 		if [[ ${file} != "*.theme" ]]; then themes+=("${file%.theme}"); fi
-		if [[ ${themes[-1]} == "${color_theme}" ]]; then theme_int=$i; fi
-		((i++))
+		if [[ ${themes[-1]} == "${color_theme}" ]]; then theme_int=${#themes[@]}-1; fi
 	done
 }
 


### PR DESCRIPTION
Don't use variable i but array current size to set current theme index.

Var i with initial value 1 doesn't work without additional themes, var i with initial value 0 doesn't work with additional themes.
