### PR TITLE
Fetch architecture from dpkg instead of hardcoded

### DIFF
--- a/DEB/build
+++ b/DEB/build
@@ -14,7 +14,7 @@ readonly   file_src_location=../bashtop             #  bashtop location  ^
 readonly   ubin=usr/bin/
 readonly   file_name=${file_src_location##*/}         
 readonly   ctrl_file=DEBIAN/control 
-readonly   architecture=amd64                       # for all architectures 
+readonly   architecture=`dpkg --print-architecture` # for all architectures 
 readonly   root_uid=0
 declare    version  build_version  
 


### PR DESCRIPTION
Small fix to the variable to output a .deb file with the architecture the script was run on rather than "amd64"