### PR TITLE
Create DOCDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ all:
 install:
 	@mkdir -p $(DESTDIR)$(PREFIX)/bin
 	@cp -p bashtop $(DESTDIR)$(PREFIX)/bin/bashtop
+	@mkdir -p $(DESTDIR)$(DOCDIR)
 	@cp -p README.md $(DESTDIR)$(DOCDIR)
 	@chmod 755 $(DESTDIR)$(PREFIX)/bin/bashtop
 


### PR DESCRIPTION
The makefile attempts to copy the README.md file to a directory that doesn't exist when I build this in my build environment. This patch ensure that the directory exists first.