### PR TITLE
escape \ in process argument

### DIFF
--- a/bashtop
+++ b/bashtop
@@ -1711,7 +1711,7 @@ collect_processes() { #? Collect process information and calculate accurate cpu 
 	 	options="-t"
 	fi
 
-	readarray ${options} proc_array < <(ps ax${tree:+f} -o pid:${proc[pid_len]}=Pid:,comm:${format_cmd}=${tree:-Program:}${format_args},nlwp:3=Tr:,euser:6=User:,pmem=Mem%,pcpu:10=Cpu% --sort ${proc[reverse]:--}${sort})
+	readarray ${options} proc_array < <(ps ax${tree:+f} -o pid:${proc[pid_len]}=Pid:,comm:${format_cmd}=${tree:-Program:}${format_args},nlwp:3=Tr:,euser:6=User:,pmem=Mem%,pcpu:10=Cpu% --sort ${proc[reverse]:--}${sort} | sed 's.\\.\\\\.g')
 
 	proc_array[0]="${proc_array[0]/      Tr:/ Threads:}"
 	proc_array[0]="${proc_array[0]/ ${selected}/${symbol}${selected}}"

--- a/bashtop
+++ b/bashtop
@@ -2103,8 +2103,9 @@ collect_processes() { #? Collect process information and calculate accurate cpu 
 	 	options="-t"
 	fi
 
-	readarray ${options} proc_array < <(ps ax${tree:+f} -o pid:${proc[pid_len]}=Pid:,comm:${format_cmd}=${tree:-Program:}${format_args},nlwp:3=Tr:,euser:6=User:,pmem=Mem%,pcpu:10=Cpu% --sort ${proc[reverse]:--}${sort} | sed 's.\\.\\\\.g')
+	readarray ${options} proc_array < <(ps ax${tree:+f} -o pid:${proc[pid_len]}=Pid:,comm:${format_cmd}=${tree:-Program:}${format_args},nlwp:3=Tr:,euser:6=User:,pmem=Mem%,pcpu:10=Cpu% --sort ${proc[reverse]:--}${sort})
 
+	proc_array=("${proc_array[@]//'\'/'\\'}")
 	proc_array[0]="${proc_array[0]/      Tr:/ Threads:}"
 	proc_array[0]="${proc_array[0]/ ${selected}/${symbol}${selected}}"
 


### PR DESCRIPTION
`ps` uses \ in the COMMAND column when a `wine` process is running.

I use `sed` to convert them to \\