### PR TITLE
Fix check for UTF-8 locale to match *.utf8

### DIFF
--- a/bashtop
+++ b/bashtop
@@ -58,7 +58,7 @@ shopt -qu failglob nullglob
 shopt -qs extglob globasciiranges globstar
 
 #* Check for UTF-8 locale and set LANG variable if not set
-if [[ ! $LANG =~ UTF-8 ]]; then
+if [[ ! $LANG =~ utf8|UTF-8 ]]; then
 	for set_lang in $(locale -a); do
 		if [[ $set_lang =~ utf8|UTF-8 ]]; then
 			declare -x LANG="${set_lang/utf8/UTF-8}"

--- a/bashtop
+++ b/bashtop
@@ -70,6 +70,8 @@ if [[ ! $LANG =~ utf8|UTF-8 ]]; then
 		echo "ERROR: No UTF-8 locale found!"
 		exit 1
 	fi
+else
+	declare -x LANG=${LANG/utf8/UTF-8}
 fi
 
 declare -a banner banner_colors


### PR DESCRIPTION
On my system `$LANG=en_US.utf8` doesn't get picked up and bashtop defaults to `aa_DJ.utf8` (not sure what language that is)