### PR TITLE
Remove extra space in debian prerm script

### DIFF
--- a/DEB/DEBIAN/prerm
+++ b/DEB/DEBIAN/prerm
@@ -1,4 +1,4 @@
 #!/bin/bash  
 
 
-echo -e "[\033[1;33m  removing packet from the system \033[0m]"
+echo -e "[\033[1;33m removing packet from the system \033[0m]"


### PR DESCRIPTION
My OCD is stirring up my guts with that extra space every time I update packages: _)

![image](https://user-images.githubusercontent.com/153305/88163516-13fcc900-cc13-11ea-96d2-99803ccbe261.png)
