### PR TITLE
Adding new themes for bashtop

### DIFF
--- a/themes/dark_green.theme
+++ b/themes/dark_green.theme
@@ -1,0 +1,89 @@
+#Bashtop theme with green colors and black background
+#by Arkagedon
+
+# Colors should be in 6 or 2 character hexadecimal or single spaced rgb decimal: "#RRGGBB", "#BW" or "0-255 0-255 0-255"
+# example for white: "#FFFFFF", "#ff" or "255 255 255".
+
+# All graphs and meters can be gradients
+# For single color graphs leave "mid" and "end" variable empty.
+# Use "start" and "end" variables for two color gradient
+# Use "start", "mid" and "end" for three color gradient
+
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#2F3C30"
+
+# Main text color
+theme[main_fg]="#cc"
+
+# Title color for boxes
+theme[title]="#ee"
+
+# Higlight color for keyboard shortcuts
+theme[hi_fg]="#3AC046"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#30AE3A" 
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#ee"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#7E7E7E"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#0DE71E"
+
+# Cpu box outline color
+theme[cpu_box]="#3D7B42"
+
+# Memory/disks box outline color
+theme[mem_box]="#2E8A35"
+
+# Net up/down box outline color
+theme[net_box]="#3BA543"
+
+# Processes box outline color
+theme[proc_box]="#35923C"
+
+# Box divider line and small boxes line color
+theme[div_line]="#30"
+
+# Temperature graph colors
+theme[temp_start]="#48D453"
+theme[temp_mid]="#54E85F"
+theme[temp_end]="#40FF4E"
+
+# CPU graph colors
+theme[cpu_start]="#50F05F"
+theme[cpu_mid]="#66F273"
+theme[cpu_end]="#1EFA32"
+
+# Mem/Disk free meter
+theme[free_start]="#143016"
+theme[free_mid]="#85E68C"
+theme[free_end]="#85FF8E"
+
+# Mem/Disk cached meter
+theme[cached_start]="#0B290D"
+theme[cached_mid]="#74FC7E"
+theme[cached_end]="#26FF36"
+
+# Mem/Disk available meter
+theme[available_start]="#07290A"
+theme[available_mid]="#7AFF84"
+theme[available_end]="#14FF29"
+
+# Mem/Disk used meter
+theme[used_start]="#1C3B1F"
+theme[used_mid]="#62D96B"
+theme[used_end]="#47FF58"
+
+# Download graph colors
+theme[download_start]="#1A6320"
+theme[download_mid]="#43A34C"
+theme[download_end]="#A9DEAE"
+
+# Upload graph colors
+theme[upload_start]="#05540C"
+theme[upload_mid]="#418047"
+theme[upload_end]="#AFDEB3"

--- a/themes/dark_orange.theme
+++ b/themes/dark_orange.theme
@@ -1,0 +1,89 @@
+#Bashtop theme with orange colors and black background
+#by Arkagedon
+
+# Colors should be in 6 or 2 character hexadecimal or single spaced rgb decimal: "#RRGGBB", "#BW" or "0-255 0-255 0-255"
+# example for white: "#FFFFFF", "#ff" or "255 255 255".
+
+# All graphs and meters can be gradients
+# For single color graphs leave "mid" and "end" variable empty.
+# Use "start" and "end" variables for two color gradient
+# Use "start", "mid" and "end" for three color gradient
+
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#3C362F"
+
+# Main text color
+theme[main_fg]="#cc"
+
+# Title color for boxes
+theme[title]="#ee"
+
+# Higlight color for keyboard shortcuts
+theme[hi_fg]="#C07D3A"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#AE6F30" 
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#ee"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#7E7E7E"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#E77A0D"
+
+# Cpu box outline color
+theme[cpu_box]="#7B5C3D"
+
+# Memory/disks box outline color
+theme[mem_box]="#8A5C2E"
+
+# Net up/down box outline color
+theme[net_box]="#A5703B"
+
+# Processes box outline color
+theme[proc_box]="#926435"
+
+# Box divider line and small boxes line color
+theme[div_line]="#30"
+
+# Temperature graph colors
+theme[temp_start]="#D48E48"
+theme[temp_mid]="#E89E54"
+theme[temp_end]="#FFA040"
+
+# CPU graph colors
+theme[cpu_start]="#F0A050"
+theme[cpu_mid]="#F2AC66"
+theme[cpu_end]="#FA8C1E"
+
+# Mem/Disk free meter
+theme[free_start]="#302214"
+theme[free_mid]="#E6B685"
+theme[free_end]="#FFC285"
+
+# Mem/Disk cached meter
+theme[cached_start]="#291A0B"
+theme[cached_mid]="#FCB874"
+theme[cached_end]="#FF9326"
+
+# Mem/Disk available meter
+theme[available_start]="#291807"
+theme[available_mid]="#FFBD7A"
+theme[available_end]="#FF8A14"
+
+# Mem/Disk used meter
+theme[used_start]="#3B2C1C"
+theme[used_mid]="#D99E62"
+theme[used_end]="#FFA347"
+
+# Download graph colors
+theme[download_start]="#633F1A"
+theme[download_mid]="#A37343"
+theme[download_end]="#DEC4A9"
+
+# Upload graph colors
+theme[upload_start]="#542D05"
+theme[upload_mid]="#806141"
+theme[upload_end]="#DEC7AF"

--- a/themes/dark_red.theme
+++ b/themes/dark_red.theme
@@ -1,0 +1,89 @@
+#Bashtop theme with red colors and black background
+#by Arkagedon
+
+# Colors should be in 6 or 2 character hexadecimal or single spaced rgb decimal: "#RRGGBB", "#BW" or "0-255 0-255 0-255"
+# example for white: "#FFFFFF", "#ff" or "255 255 255".
+
+# All graphs and meters can be gradients
+# For single color graphs leave "mid" and "end" variable empty.
+# Use "start" and "end" variables for two color gradient
+# Use "start", "mid" and "end" for three color gradient
+
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#3C2F2F"
+
+# Main text color
+theme[main_fg]="#cc"
+
+# Title color for boxes
+theme[title]="#ee"
+
+# Higlight color for keyboard shortcuts
+theme[hi_fg]="#C03A3A"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#AE3030" 
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#ee"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#7E7E7E"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#E70D0D"
+
+# Cpu box outline color
+theme[cpu_box]="#7B3D3D"
+
+# Memory/disks box outline color
+theme[mem_box]="#8A2E2E"
+
+# Net up/down box outline color
+theme[net_box]="#A53B3B"
+
+# Processes box outline color
+theme[proc_box]="#923535"
+
+# Box divider line and small boxes line color
+theme[div_line]="#30"
+
+# Temperature graph colors
+theme[temp_start]="#D44848"
+theme[temp_mid]="#E85454"
+theme[temp_end]="#FF4040"
+
+# CPU graph colors
+theme[cpu_start]="#F05050"
+theme[cpu_mid]="#F26666"
+theme[cpu_end]="#FA1E1E"
+
+# Mem/Disk free meter
+theme[free_start]="#301414"
+theme[free_mid]="#E68585"
+theme[free_end]="#FF8585"
+
+# Mem/Disk cached meter
+theme[cached_start]="#290B0B"
+theme[cached_mid]="#FC7474"
+theme[cached_end]="#FF2626"
+
+# Mem/Disk available meter
+theme[available_start]="#290707"
+theme[available_mid]="#FF7A7A"
+theme[available_end]="#FF1414"
+
+# Mem/Disk used meter
+theme[used_start]="#3B1C1C"
+theme[used_mid]="#D96262"
+theme[used_end]="#FF4747"
+
+# Download graph colors
+theme[download_start]="#631A1A"
+theme[download_mid]="#A34343"
+theme[download_end]="#DEA9A9"
+
+# Upload graph colors
+theme[upload_start]="#540505"
+theme[upload_mid]="#804141"
+theme[upload_end]="#DEAFAF"

--- a/themes/dark_yellow.theme
+++ b/themes/dark_yellow.theme
@@ -1,0 +1,89 @@
+#Bashtop theme with red colors and black background
+#by Arkagedon
+
+# Colors should be in 6 or 2 character hexadecimal or single spaced rgb decimal: "#RRGGBB", "#BW" or "0-255 0-255 0-255"
+# example for white: "#FFFFFF", "#ff" or "255 255 255".
+
+# All graphs and meters can be gradients
+# For single color graphs leave "mid" and "end" variable empty.
+# Use "start" and "end" variables for two color gradient
+# Use "start", "mid" and "end" for three color gradient
+
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#3C3C2F"
+
+# Main text color
+theme[main_fg]="#cc"
+
+# Title color for boxes
+theme[title]="#ee"
+
+# Higlight color for keyboard shortcuts
+theme[hi_fg]="#C0C03A"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#AEAE30" 
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#ee"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#7E7E7E"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#E7E70D"
+
+# Cpu box outline color
+theme[cpu_box]="#7B7B3D"
+
+# Memory/disks box outline color
+theme[mem_box]="#8A8A2E"
+
+# Net up/down box outline color
+theme[net_box]="#A5A53B"
+
+# Processes box outline color
+theme[proc_box]="#929235"
+
+# Box divider line and small boxes line color
+theme[div_line]="#30"
+
+# Temperature graph colors
+theme[temp_start]="#D4D448"
+theme[temp_mid]="#E8E854"
+theme[temp_end]="#FFFF40"
+
+# CPU graph colors
+theme[cpu_start]="#F0F050"
+theme[cpu_mid]="#F2F266"
+theme[cpu_end]="#FAFA1E"
+
+# Mem/Disk free meter
+theme[free_start]="#303014"
+theme[free_mid]="#E6E685"
+theme[free_end]="#FFFF85"
+
+# Mem/Disk cached meter
+theme[cached_start]="#29290B"
+theme[cached_mid]="#FCFC74"
+theme[cached_end]="#FFFF26"
+
+# Mem/Disk available meter
+theme[available_start]="#292907"
+theme[available_mid]="#FFFF7A"
+theme[available_end]="#FFFF14"
+
+# Mem/Disk used meter
+theme[used_start]="#3B3B1C"
+theme[used_mid]="#D9D962"
+theme[used_end]="#FFFF47"
+
+# Download graph colors
+theme[download_start]="#63631A"
+theme[download_mid]="#A3A343"
+theme[download_end]="#DEDEA9"
+
+# Upload graph colors
+theme[upload_start]="#545405"
+theme[upload_mid]="#808041"
+theme[upload_end]="#DEDEAF"

--- a/themes/index.txt
+++ b/themes/index.txt
@@ -7,3 +7,7 @@ monokai.theme
 nord.theme
 solarized_dark.theme
 whiteout.theme
+dark_green.theme
+dark_orange.theme
+dark_red.theme
+dark_yellow.theme


### PR DESCRIPTION
Hello, I have made some new themes for bashtop. All are dark themes and perfectly work with dark gtk themes.

Dark Green theme screenshot:
https://imgur.com/QOgMilJ.png

Dark Orange theme screenshot:
https://imgur.com/lRogfFe.png

Dark red theme screenshot:
https://imgur.com/7OB0BEq.png

Dark yellow theme screenshot:
https://imgur.com/gFROSsX.png