### PR TITLE
Add support Sun based distros: OpenIndiana, Illumos, ...

### DIFF
--- a/bashtop
+++ b/bashtop
@@ -41,9 +41,10 @@ case "$(uname -s)" in
 	Darwin*) system=MacOS;;
 	CYGWIN*) system=Cygwin;;
 	MINGW*)  system=MinGw;;
+        SunOS*)  system=Sun;;
 	*)       system="Other"
 esac
-if [[ ! $system =~ Linux|MacOS|BSD ]]; then
+if [[ ! $system =~ Linux|MacOS|BSD|Sun ]]; then
 	echo "This version of bashtop does not support $system platform."
 	exit 1
 fi


### PR DESCRIPTION
This small modification extends support for Sun based operating systems such as OpenIndiana, Illumos, SmartOS, ...

Works on OpenIndiana, and should work on other Sun based distros. More testing in due course.
Would be nice to have this in the main branch and make this accessible to more users.