### PR TITLE
Execution code more clear to readers and developers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Get it at https://github.com/aristocratos/btop
 * [Dependencies](#dependencies)
 * [Screenshots](#screenshots)
 * [Installation](#installation)
+* [Execution](#execution)
 * [Configurability](#configurability)
 * [TODO](#todo)
 * [License](#license)
@@ -319,6 +320,13 @@ dnf install epel-release
 dnf install bashtop
 ```
 
+#### Execution
+
+``` bash
+Execute that command to use Bashtop: bashtop
+
+```
+
 ## Configurability
 
 All options changeable from within UI.
@@ -378,13 +386,6 @@ hires_graphs="false"
 
 #* Enable the use of psutil python3 module for data collection, default on OSX
 use_psutil="true"
-```
-
-#### Command line options: (not yet implemented)
-
-``` bash
-USAGE: bashtop
-
 ```
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ dnf install epel-release
 dnf install bashtop
 ```
 
-#### Execution
+## Execution
 
 ``` bash
 Execute that command to use Bashtop: bashtop


### PR DESCRIPTION
Installation was successfully, but the message "#### Command line options: (not yet implemented)"

Was so confused I need it to find on Google how to execute bashtop.

So I, since "Command line options: (not yet implemented)" is on the To-Do list, I re indexed the project Index and Added Execution and a zone on the document, after install with "Execution" to be more clear and efficient to developers.